### PR TITLE
Fix booking confirmation status

### DIFF
--- a/src/dashboards/ClientDashboard.jsx
+++ b/src/dashboards/ClientDashboard.jsx
@@ -376,7 +376,7 @@ const ClientDashboard = () => {
                 Yes
               </button>
               <button
-                className="btn-gradient"
+                className="btn-secondary"
                 onClick={() => setPendingBooking(null)}
               >
                 No
@@ -392,7 +392,7 @@ const ClientDashboard = () => {
             <p>Are you sure you want to cancel this appointment?</p>
             <div className="flex gap-4 justify-end">
               <button
-                className="btn-secondary"
+                className="btn-primary"
                 onClick={() => {
                   cancelBooking(confirmId);
                   setConfirmId(null);
@@ -400,7 +400,7 @@ const ClientDashboard = () => {
               >
                 Yes
               </button>
-              <button className="btn-primary" onClick={() => setConfirmId(null)}>
+              <button className="btn-secondary" onClick={() => setConfirmId(null)}>
                 No
               </button>
             </div>

--- a/src/dashboards/ClientDashboard.jsx
+++ b/src/dashboards/ClientDashboard.jsx
@@ -96,7 +96,7 @@ const ClientDashboard = () => {
   useEffect(() => {
     const q = query(
       collection(db, "bookings"),
-      where("status", "==", "accepted")
+      where("status", "==", "confirmed")
     );
     const unsub = onSnapshot(q, (snap) => {
       const booked = {};
@@ -119,7 +119,7 @@ const ClientDashboard = () => {
     if (!user) return;
     const q = query(collection(db, "bookings"), where("clientId", "==", user.uid));
     const unsubscribe = onSnapshot(q, async (snap) => {
-      const accepted = snap.docs.filter((d) => d.data().status === "accepted");
+      const accepted = snap.docs.filter((d) => d.data().status === "confirmed");
       const mapped = await Promise.all(
         accepted.map(async (d) => {
           const data = { id: d.id, ...d.data() };

--- a/src/dashboards/ReaderBookings.jsx
+++ b/src/dashboards/ReaderBookings.jsx
@@ -88,7 +88,9 @@ const ReaderBookings = () => {
                     Accept
                   </button>
                   <button
-                    onClick={() => updateStatus(b.id, "rejected")}
+                    onClick={async () => {
+                      await updateStatus(b.id, "rejected");
+                    }}
                     className="bg-red-500 text-white px-4 py-1 rounded hover:bg-red-600"
                   >
                     Reject

--- a/src/dashboards/ReaderBookings.jsx
+++ b/src/dashboards/ReaderBookings.jsx
@@ -51,6 +51,10 @@ const ReaderBookings = () => {
 
   const updateStatus = async (bookingId, status) => {
     await updateDoc(doc(db, "bookings", bookingId), { status });
+    if (status !== "pending") {
+      // remove locally so pending list updates instantly
+      setBookings((prev) => prev.filter((b) => b.id !== bookingId));
+    }
   };
 
   return (
@@ -76,7 +80,9 @@ const ReaderBookings = () => {
               {b.status === "pending" && (
                 <div className="mt-4 sm:mt-0 flex gap-2">
                   <button
-                    onClick={() => updateStatus(b.id, "confirmed")}
+                    onClick={async () => {
+                      await updateStatus(b.id, "confirmed");
+                    }}
                     className="bg-green-600 text-white px-4 py-1 rounded hover:bg-green-700"
                   >
                     Accept

--- a/src/dashboards/ReaderBookings.jsx
+++ b/src/dashboards/ReaderBookings.jsx
@@ -28,7 +28,8 @@ const ReaderBookings = () => {
     if (!readerId) return;
     const q = query(
       collection(db, "bookings"),
-      where("readerId", "==", readerId)
+      where("readerId", "==", readerId),
+      where("status", "==", "pending")
     );
     const unsub = onSnapshot(q, async (snapshot) => {
       const bookingData = await Promise.all(
@@ -43,18 +44,13 @@ const ReaderBookings = () => {
           };
         })
       );
-      const pending = bookingData.filter((b) => b.status === "pending");
-      setBookings(pending);
+      setBookings(bookingData);
     });
     return () => unsub();
   }, [readerId]);
 
   const updateStatus = async (bookingId, status) => {
     await updateDoc(doc(db, "bookings", bookingId), { status });
-    if (status !== "pending") {
-      // remove locally so pending list updates instantly
-      setBookings((prev) => prev.filter((b) => b.id !== bookingId));
-    }
   };
 
   return (

--- a/src/dashboards/ReaderBookings.jsx
+++ b/src/dashboards/ReaderBookings.jsx
@@ -76,7 +76,7 @@ const ReaderBookings = () => {
               {b.status === "pending" && (
                 <div className="mt-4 sm:mt-0 flex gap-2">
                   <button
-                    onClick={() => updateStatus(b.id, "accepted")}
+                    onClick={() => updateStatus(b.id, "confirmed")}
                     className="bg-green-600 text-white px-4 py-1 rounded hover:bg-green-700"
                   >
                     Accept

--- a/src/dashboards/ReaderDashboard.jsx
+++ b/src/dashboards/ReaderDashboard.jsx
@@ -285,7 +285,7 @@ const ReaderDashboard = () => {
               <p>Are you sure you want to cancel this appointment?</p>
               <div className="flex gap-4 justify-end">
                 <button
-                  className="btn-secondary"
+                  className="btn-primary"
                   onClick={() => {
                     cancelBooking(confirmId);
                     setConfirmId(null);
@@ -293,7 +293,7 @@ const ReaderDashboard = () => {
                 >
                   Yes
                 </button>
-                <button className="btn-primary" onClick={() => setConfirmId(null)}>
+                <button className="btn-secondary" onClick={() => setConfirmId(null)}>
                   No
                 </button>
               </div>

--- a/src/dashboards/ReaderDashboard.jsx
+++ b/src/dashboards/ReaderDashboard.jsx
@@ -70,7 +70,7 @@ const ReaderDashboard = () => {
         );
         unsubAccepted = onSnapshot(acceptedQuery, async (snapshot) => {
           const acceptedDocs = snapshot.docs.filter(
-            (d) => d.data().status === "accepted"
+            (d) => d.data().status === "confirmed"
           );
           const mapped = await Promise.all(
             acceptedDocs.map(async (docSnap) => {

--- a/src/pages/BookingPage.jsx
+++ b/src/pages/BookingPage.jsx
@@ -52,7 +52,7 @@ const BookingPage = () => {
   const updateStatus = async (bookingId, status) => {
     try {
       const bookingRef = doc(db, "bookings", bookingId);
-      if (status === "accepted") {
+      if (status === "confirmed") {
         const res = await fetch("http://localhost:4000/create-room", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -157,7 +157,7 @@ const BookingPage = () => {
               <button
                 className="btn-secondary"
                 onClick={() => {
-                  updateStatus(pendingAccept.id, 'accepted');
+                  updateStatus(pendingAccept.id, 'confirmed');
                   setPendingAccept(null);
                 }}
               >

--- a/src/pages/BookingPage.jsx
+++ b/src/pages/BookingPage.jsx
@@ -156,8 +156,8 @@ const BookingPage = () => {
             <div className="flex gap-4 justify-end">
               <button
                 className="btn-secondary"
-                onClick={() => {
-                  updateStatus(pendingAccept.id, 'confirmed');
+                onClick={async () => {
+                  await updateStatus(pendingAccept.id, 'confirmed');
                   setPendingAccept(null);
                 }}
               >

--- a/src/pages/BookingPage.jsx
+++ b/src/pages/BookingPage.jsx
@@ -128,7 +128,9 @@ const BookingPage = () => {
                   Accept
                 </button>
                 <button
-                  onClick={() => updateStatus(booking.id, "rejected")}
+                  onClick={async () => {
+                    await updateStatus(booking.id, "rejected");
+                  }}
                   className="bg-yellow-500 text-white px-2 py-1 rounded text-sm"
                 >
                   Reject

--- a/src/pages/BookingPage.jsx
+++ b/src/pages/BookingPage.jsx
@@ -157,7 +157,7 @@ const BookingPage = () => {
             </p>
             <div className="flex gap-4 justify-end">
               <button
-                className="btn-secondary"
+                className="btn-primary"
                 onClick={async () => {
                   await updateStatus(pendingAccept.id, 'confirmed');
                   setPendingAccept(null);
@@ -166,7 +166,7 @@ const BookingPage = () => {
                 Yes
               </button>
               <button
-                className="btn-primary"
+                className="btn-secondary"
                 onClick={() => setPendingAccept(null)}
               >
                 No


### PR DESCRIPTION
## Summary
- ensure accepting a booking writes `confirmed` status
- show confirmed sessions in Reader dashboard and Client dashboard
- mark accepted bookings as confirmed in Reader incoming bookings

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_6848cdd7288c83319b96445f45d16441